### PR TITLE
D3ASIM-3572: show exceptions raised in threads

### DIFF
--- a/myco_api_client/cli.py
+++ b/myco_api_client/cli.py
@@ -101,5 +101,5 @@ def load_client_script(base_setup_path, setup_module_name):
     except D3AException as ex:
         raise click.BadOptionUsage(ex.args[0])
     except ModuleNotFoundError as ex:
-        log.error("Could not find the specified module")
+        log.error("Could not find the specified module: %s", ex.name)
         sys.exit(1)

--- a/myco_api_client/matchers/redis_base_matcher.py
+++ b/myco_api_client/matchers/redis_base_matcher.py
@@ -3,11 +3,11 @@ import logging
 from concurrent.futures.thread import ThreadPoolExecutor
 from typing import Dict
 
-from d3a_interface.utils import wait_until_timeout_blocking
+from d3a_interface.utils import execute_function_util, wait_until_timeout_blocking
 from redis import StrictRedis
 
-from myco_api_client.matchers.myco_matcher_client_interface import MycoMatcherClientInterface
 from myco_api_client.constants import MAX_WORKER_THREADS
+from myco_api_client.matchers.myco_matcher_client_interface import MycoMatcherClientInterface
 
 
 class RedisAPIException(Exception):
@@ -24,7 +24,7 @@ class RedisBaseMatcher(MycoMatcherClientInterface):
         self.executor = ThreadPoolExecutor(max_workers=MAX_WORKER_THREADS)
         self._get_simulation_id(is_blocking=True)
         self.redis_channels_prefix = f"external-myco/{self.simulation_id}"
-        self._subscribe_to_response_channels()       
+        self._subscribe_to_response_channels()
 
     def _set_simulation_id(self, payload):
         data = json.loads(payload["data"])
@@ -94,17 +94,17 @@ class RedisBaseMatcher(MycoMatcherClientInterface):
 
     def _on_event_or_response(self, payload: Dict):
         data = json.loads(payload["data"])
-        self.executor.submit(self.on_event_or_response, data)
+        self.executor.submit(
+            execute_function_util,
+            function=lambda: self.on_event_or_response(data),
+            function_name="on_event_or_response")
+
         # Call the corresponding event handler
         event = data.get("event")
         callback_function_name = f"_on_{event}"
         if hasattr(self, callback_function_name):
-            # Schedule the callback
-            future = self.executor.submit(getattr(self, callback_function_name), data)
-            try:
-                # Explicitly execute the call. Not doing so will cause the ThreadPoolExecutor to
-                # swallow and hide potential exceptions making it tricky to debug.
-                future.result()
-            except Exception as ex:
-                logging.exception("Exception raised by %s while executing event %s",
-                    callback_function_name, event)
+            callback_function = getattr(self, callback_function_name)
+            self.executor.submit(
+                execute_function_util,
+                function=lambda: callback_function(data),
+                function_name=callback_function_name)

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,17 @@
+"""Setup module for the myco-api-client."""
+
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
+
 from myco_api_client import __version__
 
 TARGET_BRANCH = os.environ.get("TARGET_BRANCH", "master")
 
 
 try:
-    with open('requirements/base.txt') as req:
-        REQUIREMENTS = [r.partition('#')[0] for r in req if not r.startswith('-e')]
+    with open("requirements/base.txt", encoding="utf-8") as req:
+        REQUIREMENTS = [r.partition("#")[0] for r in req if not r.startswith("-e")]
         REQUIREMENTS.extend(
             ["d3a-interface @ "
              f"git+https://github.com/gridsingularity/d3a-interface.git@{TARGET_BRANCH}"])
@@ -16,7 +20,8 @@ except OSError:
     # Shouldn't happen
     REQUIREMENTS = []
 
-with open("README.md", "r") as readme:
+
+with open("README.md", "r", encoding="utf-8") as readme:
     README = readme.read()
 
 # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
@@ -26,17 +31,17 @@ setup(
     name="myco-api-client",
     description="Myco API Client",
     long_description=README,
-    author='GridSingularity',
-    author_email='d3a@gridsingularity.com',
-    url='https://github.com/gridsingularity/myco-api-client',
+    author="GridSingularity",
+    author_email="d3a@gridsingularity.com",
+    url="https://github.com/gridsingularity/myco-api-client",
     version=VERSION,
     packages=find_packages(where=".", exclude=["tests"]),
     package_dir={"myco_api_client": "myco_api_client"},
     package_data={},
     install_requires=REQUIREMENTS,
     entry_points={
-        'console_scripts': [
-            'myco = myco_api_client.cli:main',
+        "console_scripts": [
+            "myco = myco_api_client.cli:main",
         ]
     },
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 from myco_api_client import __version__
 
-TARGET_BRANCH = os.environ.get("TARGET_BRANCH", "master")
+BRANCH = os.environ.get("BRANCH", "master")
 
 
 try:
@@ -14,7 +14,7 @@ try:
         REQUIREMENTS = [r.partition("#")[0] for r in req if not r.startswith("-e")]
         REQUIREMENTS.extend(
             ["d3a-interface @ "
-             f"git+https://github.com/gridsingularity/d3a-interface.git@{TARGET_BRANCH}"])
+             f"git+https://github.com/gridsingularity/d3a-interface.git@{BRANCH}"])
 
 except OSError:
     # Shouldn't happen

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 from myco_api_client import __version__
 
-target_branch = os.environ.get("BRANCH", "master")
+TARGET_BRANCH = os.environ.get("TARGET_BRANCH", "master")
 
 
 try:
@@ -10,7 +10,7 @@ try:
         REQUIREMENTS = [r.partition('#')[0] for r in req if not r.startswith('-e')]
         REQUIREMENTS.extend(
             ["d3a-interface @ "
-             f"git+https://github.com/gridsingularity/d3a-interface.git@{ target_branch }"])
+             f"git+https://github.com/gridsingularity/d3a-interface.git@{TARGET_BRANCH}"])
 
 except OSError:
     # Shouldn't happen

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands = python setup.py check --restructuredtext --strict
 
 [testenv:ci]
 basepython = python3.8
-passenv = LANG TERM LANGUAGE LC_ALL LD_LIBRARY_PATH
+passenv = LANG TERM LANGUAGE LC_ALL LD_LIBRARY_PATH TARGET_BRANCH
 deps =
 	pip-tools
 	coverage

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands = python setup.py check --restructuredtext --strict
 
 [testenv:ci]
 basepython = python3.8
-passenv = LANG TERM LANGUAGE LC_ALL LD_LIBRARY_PATH TARGET_BRANCH
+passenv = LANG TERM LANGUAGE LC_ALL LD_LIBRARY_PATH BRANCH
 deps =
 	pip-tools
 	coverage


### PR DESCRIPTION
The `ThreadPoolExecutor` in `RedisBaseMatcher` is executing all callbacks. However, any exception raised during the execution of these functions is not shown and it just gets swallowed by the executor. This PR fixes the issue by waiting for the result of the call and potentially logging the raised exceptions.